### PR TITLE
Reveal last selection as selection changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.7
+- Reveal active selection as selections change.
+
 ## 0.0.6
 - Fix TypeScript syntax bug.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tabsanity",
   "displayName": "TabSanity",
   "description": "Navigate or modify soft tabs as if they were hard tabs.",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "publisher": "jedmao",
   "engines": {
     "vscode": "^0.10.10"

--- a/src/TabSanity.ts
+++ b/src/TabSanity.ts
@@ -26,12 +26,12 @@ export class TabSanity {
 	}
 
 	public cursorLeft() {
-		return this.editor.selections = this.editor.selections.map(sel => {
+		return this.assignSelections(this.editor.selections.map(sel => {
 			const start = (sel.isEmpty)
 				? this.findNextLeftPosition(sel.start)
 				: sel.start;
 			return new Selection(start, start);
-		});
+		}));
 	}
 
 	private findNextLeftPosition(pos: Position) {
@@ -112,22 +112,29 @@ export class TabSanity {
 		return new Position(lineNumber, character);
 	}
 
+	private assignSelections(selections: Selection[]) {
+		const editor = this.editor;
+		editor.selections = selections;
+		editor.revealRange(editor.selections.slice(-1)[0]);
+		return selections;
+	}
+
 	public cursorLeftSelect() {
-		this.editor.selections = this.editor.selections.map(selection => {
+		return this.assignSelections(this.editor.selections.map(selection => {
 			return new Selection(
 				selection.anchor,
 				this.findNextLeftPosition(selection.active)
 			);
-		}, this);
+		}, this));
 	}
 
 	public cursorRight() {
-		return this.editor.selections = this.editor.selections.map(sel => {
+		return this.assignSelections(this.editor.selections.map(sel => {
 			const end = (sel.isEmpty)
 				? this.findNextRightPosition(sel.end)
 				: sel.end;
 			return new Selection(end, end);
-		});
+		}));
 	}
 
 	private findNextRightPosition(pos: Position) {
@@ -189,12 +196,12 @@ export class TabSanity {
 	}
 
 	public cursorRightSelect() {
-		this.editor.selections = this.editor.selections.map(selection => {
+		return this.assignSelections(this.editor.selections.map(selection => {
 			return new Selection(
 				selection.anchor,
 				this.findNextRightPosition(selection.active)
 			);
-		}, this);
+		}, this));
 	}
 
 	public async deleteLeft() {


### PR DESCRIPTION
This PR addresses an issue I found when you have multiple cursors and you navigate left or right. The issue is that the editor didn't reveal your cursor as you move outside of the editor. This PR fixes that.
