### PR TITLE
Support up/down navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
+## 0.0.10
+- Add `#cursorUp`, `#cursorUpSelect` and `#cursorDown`, `#cursorDownSelect`.
+
 ## 0.0.9
 - Fix shift+home to select to beginning of line [#12](https://github.com/jedmao/vscode-tabsanity/pull/12). Thanks [@Lavinski](https://github.com/Lavinski)!
 
 ## 0.0.8
-- Add `#cursorHomeSelect` and `#cursorEndSelect`
+- Add `#cursorHomeSelect` and `#cursorEndSelect`.
 
 ## 0.0.7
 - Reveal active selection as selections change.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tabsanity",
   "displayName": "TabSanity",
   "description": "Navigate or modify soft tabs as if they were hard tabs.",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "publisher": "jedmao",
   "engines": {
     "vscode": "^1.9.1"
@@ -13,6 +13,10 @@
     "Other"
   ],
   "activationEvents": [
+    "onCommand:tabsanity.cursorUp",
+    "onCommand:tabsanity.cursorUpSelect",
+    "onCommand:tabsanity.cursorDown",
+    "onCommand:tabsanity.cursorDownSelect",
     "onCommand:tabsanity.cursorLeft",
     "onCommand:tabsanity.cursorLeftSelect",
     "onCommand:tabsanity.cursorHomeSelect",
@@ -25,6 +29,26 @@
   "main": "./out/src/extension",
   "contributes": {
     "keybindings": [
+      {
+        "key": "up",
+        "command": "tabsanity.cursorUp",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "shift+up",
+        "command": "tabsanity.cursorUpSelect",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "down",
+        "command": "tabsanity.cursorDown",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "shift+down",
+        "command": "tabsanity.cursorDownSelect",
+        "when": "editorTextFocus"
+      },
       {
         "key": "left",
         "command": "tabsanity.cursorLeft",
@@ -73,20 +97,44 @@
     ],
     "commands": [
       {
+        "command": "tabsanity.cursorUp",
+        "title": "TabSanity: Move cursor(s) up"
+      },
+      {
+        "command": "tabsanity.cursorUpSelect",
+        "title": "TabSanity: Move cursor(s) up and select"
+      },
+      {
+        "command": "tabsanity.cursorDown",
+        "title": "TabSanity: Move cursor(s) down"
+      },
+      {
+        "command": "tabsanity.cursorDownSelect",
+        "title": "TabSanity: Move cursor(s) down and select"
+      },
+      {
         "command": "tabsanity.cursorLeft",
-        "title": "TabSanity: Move cursor left"
+        "title": "TabSanity: Move cursor(s) left"
       },
       {
         "command": "tabsanity.cursorLeftSelect",
-        "title": "TabSanity: Move cursor left and select"
+        "title": "TabSanity: Move cursor(s) left and select"
+      },
+      {
+        "command": "tabsanity.cursorHomeSelect",
+        "title": "TabSanity: Move cursor(s) home and select"
       },
       {
         "command": "tabsanity.cursorRight",
-        "title": "TabSanity: Move cursor right"
+        "title": "TabSanity: Move cursor(s) right"
       },
       {
         "command": "tabsanity.cursorRightSelect",
-        "title": "TabSanity: Move cursor right and select"
+        "title": "TabSanity: Move cursor(s) right and select"
+      },
+      {
+        "command": "tabsanity.cursorEndSelect",
+        "title": "TabSanity: Move cursor(s) end and select"
       },
       {
         "command": "tabsanity.deleteLeft",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,10 @@ export function activate(context: ExtensionContext) {
 	Array.prototype.push.apply(
 		context.subscriptions,
 		[
+			'cursorUp',
+			'cursorUpSelect',
+			'cursorDown',
+			'cursorDownSelect',
 			'cursorLeft',
 			'cursorLeftSelect',
 			'cursorHomeSelect',


### PR DESCRIPTION
Fixes #4
- [x] Add up/down (select) activation events.
- [x] Add up/down (select) key bindings.
- [x] Add up/down (select) commands.
- [x] Add up/down (select) methods to TabSanity class.
- [x] Adjust cursor position to a tab stop if it lands within a soft tab.
- [ ] Restore cursor character position when leaving an adjusted tab stop.
  - Extracted into #15 
- [x] Update changelog.

Note: May be able to use [`cursorMove` complex command](https://code.visualstudio.com/docs/extensionAPI/vscode-api-commands).
