### PR TITLE
Remove redundant delete handling (#17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "onCommand:tabsanity.cursorHomeSelect",
     "onCommand:tabsanity.cursorRight",
     "onCommand:tabsanity.cursorRightSelect",
-    "onCommand:tabsanity.cursorEndSelect",
-    "onCommand:tabsanity.deleteLeft",
-    "onCommand:tabsanity.deleteRight"
+    "onCommand:tabsanity.cursorEndSelect"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -54,21 +52,6 @@
         "key": "shift+end",
         "command": "tabsanity.cursorEndSelect",
         "when": "editorTextFocus"
-      },
-      {
-        "key": "shift+backspace",
-        "command": "tabsanity.deleteLeft",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "backspace",
-        "command": "tabsanity.deleteLeft",
-        "when": "editorTextFocus"
-      },
-      {
-        "key": "delete",
-        "command": "tabsanity.deleteRight",
-        "when": "editorTextFocus"
       }
     ],
     "commands": [
@@ -87,14 +70,6 @@
       {
         "command": "tabsanity.cursorRightSelect",
         "title": "TabSanity: Move cursor right and select"
-      },
-      {
-        "command": "tabsanity.deleteLeft",
-        "title": "TabSanity: Delete left"
-      },
-      {
-        "command": "tabsanity.deleteRight",
-        "title": "TabSanity: Delete right"
       }
     ]
   },

--- a/src/TabSanity.ts
+++ b/src/TabSanity.ts
@@ -230,39 +230,4 @@ export class TabSanity {
 		}, this));
 	}
 
-	public async deleteLeft() {
-		for (let selection of this.editor.selections) {
-			const start = selection.start;
-			if (!selection.isEmpty) {
-				await this.delete(selection);
-				continue;
-			}
-			const deleteStartPosition = this.findNextLeftPosition(start);
-			if (deleteStartPosition) {
-				await this.delete(new Range(deleteStartPosition, start));
-			}
-		}
-		this.editor.revealRange(this.editor.selection);
-	}
-
-	private delete(location: Range|Selection) {
-		return this.editor.edit(edit => {
-			edit.delete(location);
-		});
-	}
-
-	public async deleteRight() {
-		for (let selection of this.editor.selections) {
-			const end = selection.end;
-			if (!selection.isEmpty) {
-				await this.delete(selection);
-				continue;
-			}
-			const deleteEndPosition = this.findNextRightPosition(end);
-			if (deleteEndPosition) {
-				await this.delete(new Range(end, deleteEndPosition));
-			}
-		}
-	}
-
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,9 +17,7 @@ export function activate(context: ExtensionContext) {
 			'cursorHomeSelect',
 			'cursorRight',
 			'cursorRightSelect',
-			'cursorEndSelect',
-			'deleteLeft',
-			'deleteRight'
+			'cursorEndSelect'
 		].map(command => {
 			return commands.registerCommand(
 				`tabsanity.${command}`,


### PR DESCRIPTION
Since VS Code now handles deletion of space indentation correctly, having
this functionality doesn't provide any benefit, but it impedes the correct
handling of matching brace deletion.

This fixes issue #17.