### PR TITLE
v0.0.11 - Restore "delete right" functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.11
+- Restore "delete right" functionality.
+
 ## 0.0.10
 - Fix/remove backspace + delete functionality, which is now baked into vscode [#17](https://github.com/jedmao/vscode-tabsanity/issues/17).
 - Update dev dependencies.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tabsanity",
   "displayName": "TabSanity",
   "description": "Navigate or modify soft tabs as if they were hard tabs.",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "publisher": "jedmao",
   "engines": {
     "vscode": "^1.23.1"
@@ -18,7 +18,8 @@
     "onCommand:tabsanity.cursorHomeSelect",
     "onCommand:tabsanity.cursorRight",
     "onCommand:tabsanity.cursorRightSelect",
-    "onCommand:tabsanity.cursorEndSelect"
+    "onCommand:tabsanity.cursorEndSelect",
+    "onCommand:tabsanity.deleteRight"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -52,6 +53,11 @@
         "key": "shift+end",
         "command": "tabsanity.cursorEndSelect",
         "when": "editorTextFocus"
+      },
+      {
+        "key": "delete",
+        "command": "tabsanity.deleteRight",
+        "when": "editorTextFocus"
       }
     ],
     "commands": [
@@ -70,6 +76,10 @@
       {
         "command": "tabsanity.cursorRightSelect",
         "title": "TabSanity: Move cursor right and select"
+      },
+      {
+        "command": "tabsanity.deleteRight",
+        "title": "TabSanity: Delete right"
       }
     ]
   },

--- a/src/TabSanity.ts
+++ b/src/TabSanity.ts
@@ -230,4 +230,24 @@ export class TabSanity {
 		}, this));
 	}
 
+	private delete(location: Range | Selection) {
+		return this.editor.edit(edit => {
+			edit.delete(location);
+		});
+	}
+
+	public async deleteRight() {
+		for (let selection of this.editor.selections) {
+			const end = selection.end;
+			if (!selection.isEmpty) {
+				await this.delete(selection);
+				continue;
+			}
+			const deleteEndPosition = this.findNextRightPosition(end);
+			if (deleteEndPosition) {
+				await this.delete(new Range(end, deleteEndPosition));
+			}
+		}
+	}
+
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,8 @@ export function activate(context: ExtensionContext) {
 			'cursorHomeSelect',
 			'cursorRight',
 			'cursorRightSelect',
-			'cursorEndSelect'
+			'cursorEndSelect',
+			'deleteRight',
 		].map(command => {
 			return commands.registerCommand(
 				`tabsanity.${command}`,


### PR DESCRIPTION
## 0.0.11
- Restore "delete right" functionality.

Because it seems it's not working out-of-the-box in vscode.